### PR TITLE
Правки в пространстве имен/Namespace edits

### DIFF
--- a/src/Oscallo.Castle.AddonedKernel.Demo/App.xaml.cs
+++ b/src/Oscallo.Castle.AddonedKernel.Demo/App.xaml.cs
@@ -18,7 +18,7 @@ using Oscallo.Castle.AddonedKernel.Demo.DI;
 using Oscallo.Castle.AddonedKernel.Demo.IntegrableClasses;
 using Oscallo.Castle.AddonedKernel.Demo.MVVM;
 using Oscallo.Castle.AddonedKernel.Demo.Services;
-using Oscallo.Castle.AddonedKernel.Integrators;
+using Oscallo.Castle.AddonedKernel.Injectors;
 using Castle.MicroKernel.Registration;
 using Castle.Windsor;
 using System.Collections.Generic;

--- a/src/Oscallo.Castle.AddonedKernel.Demo/DI/Injector.cs
+++ b/src/Oscallo.Castle.AddonedKernel.Demo/DI/Injector.cs
@@ -14,7 +14,7 @@
  */
 
 using Oscallo.Castle.AddonedKernel.Demo.Services;
-using Oscallo.Castle.AddonedKernel.Integrators;
+using Oscallo.Castle.AddonedKernel.Injectors;
 using Castle.MicroKernel;
 using Castle.MicroKernel.Registration;
 using Castle.Windsor;

--- a/src/Oscallo.Castle.AddonedKernel.Demo/IntegrableClasses/MiddleOrderWithDepClass.cs
+++ b/src/Oscallo.Castle.AddonedKernel.Demo/IntegrableClasses/MiddleOrderWithDepClass.cs
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-using Oscallo.Castle.AddonedKernel.Integrators;
+using Oscallo.Castle.AddonedKernel.Injectors;
 using Castle.MicroKernel.Registration;
 using Oscallo.Castle.AddonedKernel.IntegrableInterfaces;
 

--- a/src/Oscallo.Castle.AddonedKernel.Demo/IntegrableClasses/UpperOrderClass.cs
+++ b/src/Oscallo.Castle.AddonedKernel.Demo/IntegrableClasses/UpperOrderClass.cs
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-using Oscallo.Castle.AddonedKernel.Integrators;
+using Oscallo.Castle.AddonedKernel.Injectors;
 using Castle.MicroKernel.Registration;
 using Oscallo.Castle.AddonedKernel.IntegrableInterfaces;
 

--- a/src/Oscallo.Castle.AddonedKernel.Demo/MainWindow.xaml.cs
+++ b/src/Oscallo.Castle.AddonedKernel.Demo/MainWindow.xaml.cs
@@ -17,7 +17,7 @@ using Castle.MicroKernel.Registration;
 using Oscallo.Castle.AddonedKernel.Demo.MVVM;
 using Oscallo.Castle.AddonedKernel.Demo.Services;
 using Oscallo.Castle.AddonedKernel.IntegrableInterfaces;
-using Oscallo.Castle.AddonedKernel.Integrators;
+using Oscallo.Castle.AddonedKernel.Injectors;
 using System.Windows;
 
 namespace Oscallo.Castle.AddonedKernel.Demo

--- a/src/Oscallo.Castle.AddonedKernel/Injectors/IContainerRegistrar.cs
+++ b/src/Oscallo.Castle.AddonedKernel/Injectors/IContainerRegistrar.cs
@@ -13,11 +13,18 @@
  * limitations under the License.
  */
 
-namespace Oscallo.Castle.AddonedKernel.Integrators
+using Castle.Windsor;
+using System;
+
+namespace Oscallo.Castle.AddonedKernel.Injectors
 {
-
-	public interface IInjector : IRegistrar, IContainerRegistrar, IResolver
+	/// <summary>
+	/// Контракт, гарантирующий добавление и удаление дочернего контейнера
+	/// </summary>
+    public interface IContainerRegistrar : IDisposable
     {
+        void AddChildContainer(IWindsorContainer windsorContainer);
 
+        void RemoveChildContainer(IWindsorContainer windsorContainer);
     }
 }

--- a/src/Oscallo.Castle.AddonedKernel/Injectors/IInjector.cs
+++ b/src/Oscallo.Castle.AddonedKernel/Injectors/IInjector.cs
@@ -13,18 +13,11 @@
  * limitations under the License.
  */
 
-using Castle.Windsor;
-using System;
-
-namespace Oscallo.Castle.AddonedKernel.Integrators
+namespace Oscallo.Castle.AddonedKernel.Injectors
 {
-	/// <summary>
-	/// Контракт, гарантирующий добавление и удаление дочернего контейнера
-	/// </summary>
-    public interface IContainerRegistrar : IDisposable
-    {
-        void AddChildContainer(IWindsorContainer windsorContainer);
 
-        void RemoveChildContainer(IWindsorContainer windsorContainer);
+	public interface IInjector : IRegistrar, IContainerRegistrar, IResolver
+    {
+
     }
 }

--- a/src/Oscallo.Castle.AddonedKernel/Injectors/IRegistrar.cs
+++ b/src/Oscallo.Castle.AddonedKernel/Injectors/IRegistrar.cs
@@ -17,7 +17,7 @@ using Castle.MicroKernel;
 using Castle.MicroKernel.Registration;
 using System;
 
-namespace Oscallo.Castle.AddonedKernel.Integrators
+namespace Oscallo.Castle.AddonedKernel.Injectors
 {
 	/// <summary>
 	/// Контракт, гарантирующий, что сущность будет иметь функцмонал регистрации зависимостей

--- a/src/Oscallo.Castle.AddonedKernel/Injectors/IResolver.cs
+++ b/src/Oscallo.Castle.AddonedKernel/Injectors/IResolver.cs
@@ -16,7 +16,7 @@
 using Castle.MicroKernel;
 using System;
 
-namespace Oscallo.Castle.AddonedKernel.Integrators
+namespace Oscallo.Castle.AddonedKernel.Injectors
 {
     public interface IResolver : IDisposable
     {

--- a/src/Oscallo.Castle.AddonedKernel/IntegrableInterfaces/IIntegrator.cs
+++ b/src/Oscallo.Castle.AddonedKernel/IntegrableInterfaces/IIntegrator.cs
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-using Oscallo.Castle.AddonedKernel.Integrators;
+using Oscallo.Castle.AddonedKernel.Injectors;
 
 namespace Oscallo.Castle.AddonedKernel.IntegrableInterfaces
 {


### PR DESCRIPTION
RU: Исправлено пространство имен Injectors на более подходящее.
EN: Corrected the Injectors namespace to be more appropriate.